### PR TITLE
Updating http-router version due to compile error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Placid.Mixfile do
 
   def project do
     [ app: :placid,
-      version: "0.1.4-beta.1",
+      version: "0.1.4",
       elixir: ">= 1.0.0-rc1",
       deps: deps,
       name: "Placid",

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Placid.Mixfile do
 
   def project do
     [ app: :placid,
-      version: "0.1.3",
+      version: "0.1.4-beta.1",
       elixir: ">= 1.0.0-rc1",
       deps: deps,
       name: "Placid",

--- a/mix.exs
+++ b/mix.exs
@@ -22,9 +22,9 @@ defmodule Placid.Mixfile do
   defp deps do
     [ { :cowboy, "~> 1.0.0" },
       { :plug, "~> 0.9.0" },
-      { :http_router, "~> 0.0.3" },
+      { :http_router, "~> 0.0.4" },
       { :linguist, "~> 0.1.2" },
-      { :poison, "~> 1.2.0" },
+      { :poison, "~> 1.3.0" },
       { :xml_builder, "~> 0.0.5" },
       { :earmark, "~> 0.1.10", only: :docs },
       { :ex_doc, "~> 0.6.1", only: :docs },

--- a/mix.lock
+++ b/mix.lock
@@ -4,11 +4,11 @@
   "earmark": {:hex, :earmark, "0.1.10"},
   "ex_doc": {:hex, :ex_doc, "0.6.1"},
   "excoveralls": {:hex, :excoveralls, "0.3.4"},
-  "http_router": {:hex, :http_router, "0.0.3"},
+  "http_router": {:hex, :http_router, "0.0.4"},
   "jsex": {:hex, :jsex, "2.0.0"},
   "jsx": {:hex, :jsx, "2.1.1"},
   "linguist": {:hex, :linguist, "0.1.2"},
   "plug": {:hex, :plug, "0.9.0"},
-  "poison": {:hex, :poison, "1.2.1"},
+  "poison": {:hex, :poison, "1.3.1"},
   "ranch": {:hex, :ranch, "1.0.0"},
   "xml_builder": {:hex, :xml_builder, "0.0.5"}}


### PR DESCRIPTION
I was trying to use `placid` for the first time based on the kitchen-sink example, but I stumbled on an error when running `mix compile`:
```
Compiled lib/handlers/v1/main.ex

== Compilation error on file lib/router.ex ==
** (CompileError) lib/router.ex:1: function send_resp/3 undefined
    (stdlib) lists.erl:1336: :lists.foreach/2
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
```

My router:
```elixir
defmodule Kiwi.Router do
  use Placid.Router
  alias Kiwi.Handlers.V1

  version "v1" do
    get "/", V1.Main, :index
  end
end
```
After some investigation I found that the latest `placid` version uses the `http-router#0.0.3`, that calls that undefined `send_resp/3`. Than when I updated to `http-router#0.0.4` and ran my project it compiled just fine.